### PR TITLE
Point the site list at who actually announces these tournaments

### DIFF
--- a/scraper/config.yaml
+++ b/scraper/config.yaml
@@ -109,7 +109,26 @@ sources:
       - url: https://www.tulaliptribes-nsn.gov/GeneralServices/Events
         tribe: Tulalip
         location: Tulalip, WA
-      # Casinos host a lot of these tournaments.
+      # Casinos host a lot of these tournaments — and this is where they get
+      # announced. Found 2026-08-12 by searching for real tournaments rather
+      # than assuming tribal government sites would carry them: every one of
+      # these scores 1.0 on the topic filter, while the .gov and .nsn.us
+      # homepages score 0.0. Several tribes run a dedicated stickgame page on
+      # the casino site and nothing at all on the tribal site.
+      - url: https://spokanetribecasino.com/2026-stick-games/
+        tribe: Spokane
+        location: Airway Heights, WA
+      - url: https://www.cdacasino.com/events/
+        tribe: Coeur d'Alene
+        location: Worley, ID
+        hint: stickgame tournament
+      - url: https://www.rsic.org/269/Numaga-Indian-Days-Powwow-Handgames
+        tribe: Reno-Sparks Indian Colony
+        location: Reno, NV
+      # Regional aggregator covering the Great Basin, which the tribal-site
+      # list misses entirely.
+      - url: https://nevadasindianterritory.com/powwows-calendar/
+        hint: powwow handgame stickgame
       - url: https://www.northernquest.com/entertainment
         location: Airway Heights, WA
         hint: stickgame handgame tournament


### PR DESCRIPTION
Follow-up to #2. One commit, `config.yaml` only — no code changes.

## The web adapters returned zero because the site list was wrong

#2 shipped the collector working correctly and finding nothing, and I took "zero events" as the honest answer because the code was demonstrably behaving: Tulalip parsed 19 events cleanly and scored them all 0.00 correctly.

The code was fine. The **list** was wrong. It had been assembled by naming tribes, so it points at tribal government homepages — and those do not carry tournaments. Several of these tribes run a dedicated stickgame page on their casino site and nothing at all on the tribal site.

Found by searching for actual tournaments instead of listing tribes:

| Source | Topic score |
|---|---|
| `spokanetribecasino.com/2026-stick-games/` | **1.0** |
| `cdacasino.com/events/` | **1.0** |
| `rsic.org` — Numaga Indian Days | **1.0** |
| `nevadasindianterritory.com/powwows-calendar/` | **1.0** |
| *the .gov / .nsn.us homepages already in the list* | *0.0* |

`nevadasindianterritory.com` also covers the Great Basin, which a list built from Plateau tribes misses entirely.

## Result

```
                     before      after
collected                 0         42
queued for review         0          9   (5 carrying warnings)
```

Including a real one: **First Annual Stick Game Tournament, 2027-05-22**, off the Spokane Tribe Casino page.

## This still needs a person

Some titles come through as "Event Details" from a calendar widget, and one page's dates are stale. That is the review queue doing its job rather than publishing junk — nothing here reaches the site without someone clicking Approve.

## Not done

Four sources came from two web searches. Finding them by searching for tournaments, rather than by listing tribes, obviously works and has not been done systematically. That is the highest-value remaining work on the config.

Tests unchanged and green: 67 + 44 + 89 + 26 = 226.
